### PR TITLE
[ISSUE-112] 전체 일정 리스트 저장 기능 추가 관련 수정

### DIFF
--- a/app/src/main/java/com/example/codetour/RouteCheck.java
+++ b/app/src/main/java/com/example/codetour/RouteCheck.java
@@ -354,6 +354,8 @@ public class RouteCheck extends AppCompatActivity implements  ScheduleContract.V
             ScheduleService.getInstance().addSchedule(tripSchedule);
         }
 
+        SaveLoadManager.saveTripScheduleList(this, "scheduleList", ScheduleService.getInstance().tripScheduleList);
+
         Intent intent = new Intent(this,ScheduleList.class);
         startActivityForResult(intent,0);
     }

--- a/app/src/main/java/com/example/codetour/ScheduleList.java
+++ b/app/src/main/java/com/example/codetour/ScheduleList.java
@@ -29,8 +29,8 @@ public class ScheduleList extends AppCompatActivity implements ScheduleListContr
         textView.setPaintFlags(textView.getPaintFlags() | Paint.FAKE_BOLD_TEXT_FLAG);
 
         scheduleListPresenter = new ScheduleListPresenter(this);
+        scheduleListPresenter.loadScheduleList(this, "scheduleList");
         scheduleListPresenter.getScheduleList();
-
     }
 
     public void backMainActivity(View view){    //홈으로 돌아가는 버튼 onClick

--- a/app/src/main/java/com/example/codetour/ScheduleListContract.java
+++ b/app/src/main/java/com/example/codetour/ScheduleListContract.java
@@ -1,5 +1,7 @@
 package com.example.codetour;
 
+import android.content.Context;
+
 import java.util.List;
 
 public interface ScheduleListContract{
@@ -11,5 +13,6 @@ public interface ScheduleListContract{
     interface Presenter extends BaseContract.Presenter<View>{
         void getScheduleList();
         void getSchdule(int position);
+        void loadScheduleList(Context ctx, String key);
     }
 }

--- a/app/src/main/java/com/example/codetour/ScheduleListPresenter.java
+++ b/app/src/main/java/com/example/codetour/ScheduleListPresenter.java
@@ -1,5 +1,7 @@
 package com.example.codetour;
 
+import android.content.Context;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,5 +38,10 @@ public class ScheduleListPresenter implements ScheduleListContract.Presenter {
         rec.setTripSchedule(ScheduleService.getInstance().tripScheduleList.get(position));
         scheduleListView.showSchedule(rec);
 
+    }
+
+    @Override
+    public void loadScheduleList(Context ctx, String key){
+        ScheduleService.getInstance().tripScheduleList = SaveLoadManager.loadTripScheduleList(ctx, key);
     }
 }

--- a/app/src/main/java/com/example/codetour/TripSchedule.java
+++ b/app/src/main/java/com/example/codetour/TripSchedule.java
@@ -125,6 +125,8 @@ public class TripSchedule implements Serializable{
             tourBudget = obj.getInt("tourBudget");
             accBudget = obj.getInt("accBudget");
 
+            save = obj.getBoolean("save");
+
             food_selection = new ArrayList<Integer>();
             JSONArray food_selection_tmp = obj.getJSONArray("food_selection");
             int len_food = food_selection_tmp.length();
@@ -220,6 +222,8 @@ public class TripSchedule implements Serializable{
             ret.put("pNum", pNum);
             ret.put("tourBudget", tourBudget);
             ret.put("accBudget", accBudget);
+
+            ret.put("save", save);
 
             int food_selection_len = food_selection.size();
             for(int i=0; i<food_selection_len; ++i){


### PR DESCRIPTION
Tripschedule 내의 save변수도 같이 저장되도록 수정
RouteCheck에서 ScheduleList로 넘어가기 직전에, 모든 리스트를 저장하도록 수정
ScheduleList의 onCreate()가 호출될 때, 모든 리스트가 로드되도록 수정: 관련 Contract와 Presenter도 같이 수정